### PR TITLE
Add Tron-style neon hero theme, drop Stack Overflow link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,4 +3,5 @@
 </footer>
 <script src="{{ "/assets/js/sweet-scroll.min.js" | prepend: site.baseurl }}"></script>
 <script src="{{ "/assets/js/main.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/assets/js/parallax.js" | prepend: site.baseurl }}"></script>
 {% include google-analytics.html %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,4 +7,5 @@
   <meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ "/assets/css/tron.css" | prepend: site.baseurl }}">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,9 @@
 <div id="particles-js">
+  <div class="tron-bg" aria-hidden="true">
+    <div class="tron-sun"></div>
+    <div class="tron-grid"></div>
+    <div class="tron-stars"></div>
+  </div>
   <div class="header">
       <h1>
         <span class="site-title">{{site.username}}</span>
@@ -8,7 +13,6 @@
         <a aria-label="Send email" href="mailto:{{site.email}}"><i class="icon fa fa-envelope"></i></a>
         <a aria-label="My Github" target="_blank" href="https://github.com/benrowe"><i class="icon fa fa-github-alt" aria-hidden="true"></i></a>
         <a aria-label="My Linkedin" target="_blank" href="https://www.linkedin.com/in/ben-rowe/"><i class="icon fa fa-linkedin" aria-hidden="true"></i></a>
-        <a aria-label="My Stackoverflow" target="_blank" href="https://stackoverflow.com/users/123429/ben-rowe"><i class="icon fa fa-stack-overflow" aria-hidden="true"></i></a>
       </div>
   </div>
 </div>

--- a/assets/css/tron.css
+++ b/assets/css/tron.css
@@ -1,0 +1,133 @@
+#particles-js {
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% 30%, #1a1040 0%, #0a0e1a 60%, #000 100%);
+}
+
+.tron-bg {
+  position: absolute;
+  top: 0; right: 0; bottom: 0; left: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+  will-change: transform;
+}
+
+.tron-sun {
+  position: absolute;
+  left: 50%;
+  top: 38%;
+  width: 280px;
+  height: 280px;
+  transform: translate(calc(-50% + var(--px, 0) * 8px), calc(-50% + var(--py, 0) * 6px));
+  border-radius: 50%;
+  background: linear-gradient(180deg, #ff2fd0 0%, #7b2ff7 50%, transparent 100%);
+  box-shadow: 0 0 60px 20px rgba(255, 47, 208, 0.6), 0 0 120px 40px rgba(123, 47, 247, 0.3);
+  animation: sun-pulse 4s ease-in-out infinite;
+}
+
+@media only screen and (min-width: 550px) {
+  .tron-sun {
+    width: 420px;
+    height: 420px;
+  }
+}
+
+@media only screen and (max-width: 550px) {
+  .tron-sun {
+    box-shadow: 0 0 30px 10px rgba(255, 47, 208, 0.6), 0 0 60px 20px rgba(123, 47, 247, 0.3);
+  }
+}
+
+.tron-grid {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 50%;
+  background-image: repeating-linear-gradient(to right, rgba(0, 255, 240, 0.35) 0 2px, transparent 2px 60px);
+  transform: perspective(300px) rotateX(65deg) translate(calc(var(--px, 0) * 20px), calc(var(--py, 0) * 14px));
+  transform-origin: bottom center;
+  -webkit-mask-image: linear-gradient(to top, black 0%, transparent 90%);
+  mask-image: linear-gradient(to top, black 0%, transparent 90%);
+}
+
+.tron-grid::before {
+  content: "";
+  position: absolute;
+  top: 0; right: 0; bottom: 0; left: 0;
+  background-image: repeating-linear-gradient(to top, rgba(0, 255, 240, 0.35) 0 2px, transparent 2px 60px);
+  animation: grid-scroll 2s linear infinite;
+}
+
+.tron-stars {
+  position: absolute;
+  top: 0; right: 0; bottom: 0; left: 0;
+  opacity: 0.6;
+  transform: translate(calc(var(--px, 0) * 4px), calc(var(--py, 0) * 3px));
+  background-image:
+    radial-gradient(1px 1px at 10% 20%, #fff, transparent),
+    radial-gradient(1px 1px at 25% 55%, #fff, transparent),
+    radial-gradient(1px 1px at 40% 15%, #fff, transparent),
+    radial-gradient(1px 1px at 55% 65%, #fff, transparent),
+    radial-gradient(1px 1px at 70% 25%, #fff, transparent),
+    radial-gradient(1px 1px at 85% 50%, #fff, transparent),
+    radial-gradient(1px 1px at 92% 10%, #fff, transparent),
+    radial-gradient(1px 1px at 15% 80%, #fff, transparent),
+    radial-gradient(2px 2px at 80% 75%, #00fff0, transparent),
+    radial-gradient(2px 2px at 35% 35%, #00fff0, transparent);
+}
+
+@keyframes sun-pulse {
+  0%, 100% {
+    opacity: 0.85;
+    filter: brightness(1);
+  }
+  50% {
+    opacity: 1;
+    filter: brightness(1.15);
+  }
+}
+
+@keyframes grid-scroll {
+  from { background-position: 0 0; }
+  to { background-position: 0 60px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tron-sun,
+  .tron-grid::before {
+    animation: none !important;
+  }
+}
+
+.site-title,
+.site-description {
+  color: #00fff0;
+  text-shadow:
+    0 0 6px rgba(0, 255, 240, 0.8),
+    0 0 16px rgba(0, 255, 240, 0.5),
+    0 0 32px rgba(123, 47, 247, 0.4);
+}
+
+.header-icons .icon {
+  color: #00fff0;
+  border-color: #00fff0;
+  box-shadow: 0 0 8px rgba(0, 255, 240, 0.6);
+}
+
+.header-icons .icon:hover,
+.header-icons .icon:active {
+  color: #0a0e1a;
+  background: #00fff0;
+  box-shadow: 0 0 16px rgba(0, 255, 240, 0.9), 0 0 32px rgba(255, 47, 208, 0.5);
+}
+
+.footer {
+  background: #0a0e1a;
+}
+
+.footer a:hover,
+.footer a:active {
+  color: #00fff0;
+}

--- a/assets/js/parallax.js
+++ b/assets/js/parallax.js
@@ -1,0 +1,28 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var bg = document.querySelector(".tron-bg");
+  if (!bg) return;
+
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  var targetX = 0, targetY = 0;
+  var currentX = 0, currentY = 0;
+
+  document.addEventListener("mousemove", function (e) {
+    targetX = (e.clientX / window.innerWidth - 0.5) * 2;
+    targetY = (e.clientY / window.innerHeight - 0.5) * 2;
+  }, { passive: true });
+
+  function tick() {
+    currentX += (targetX - currentX) * 0.05;
+    currentY += (targetY - currentY) * 0.05;
+
+    var scrollOffset = window.scrollY * 0.05;
+
+    bg.style.setProperty("--px", currentX.toFixed(3));
+    bg.style.setProperty("--py", (currentY + scrollOffset).toFixed(3));
+
+    requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
+}, false);

--- a/src/js/parallax.js
+++ b/src/js/parallax.js
@@ -1,0 +1,28 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var bg = document.querySelector(".tron-bg");
+  if (!bg) return;
+
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  var targetX = 0, targetY = 0;
+  var currentX = 0, currentY = 0;
+
+  document.addEventListener("mousemove", function (e) {
+    targetX = (e.clientX / window.innerWidth - 0.5) * 2;
+    targetY = (e.clientY / window.innerHeight - 0.5) * 2;
+  }, { passive: true });
+
+  function tick() {
+    currentX += (targetX - currentX) * 0.05;
+    currentY += (targetY - currentY) * 0.05;
+
+    var scrollOffset = window.scrollY * 0.05;
+
+    bg.style.setProperty("--px", currentX.toFixed(3));
+    bg.style.setProperty("--py", (currentY + scrollOffset).toFixed(3));
+
+    requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
+}, false);

--- a/src/styles/_tron.scss
+++ b/src/styles/_tron.scss
@@ -1,0 +1,122 @@
+#particles-js {
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% 30%, #1a1040 0%, $void 60%, #000 100%);
+}
+
+.tron-bg {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+  will-change: transform;
+}
+
+.tron-sun {
+  position: absolute;
+  left: 50%;
+  top: 38%;
+  width: 280px;
+  height: 280px;
+  transform: translate(calc(-50% + var(--px, 0) * 8px), calc(-50% + var(--py, 0) * 6px));
+  border-radius: 50%;
+  background: linear-gradient(180deg, $neon-magenta 0%, $neon-purple 50%, transparent 100%);
+  box-shadow: 0 0 60px 20px rgba(255, 47, 208, 0.6), 0 0 120px 40px rgba(123, 47, 247, 0.3);
+  animation: sun-pulse 4s ease-in-out infinite;
+  @media only screen and (min-width: $cut) {
+    width: 420px;
+    height: 420px;
+  }
+  @media only screen and (max-width: $cut) {
+    box-shadow: 0 0 30px 10px rgba(255, 47, 208, 0.6), 0 0 60px 20px rgba(123, 47, 247, 0.3);
+  }
+}
+
+.tron-grid {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 50%;
+  background-image: repeating-linear-gradient(to right, $grid-line 0 2px, transparent 2px 60px);
+  transform: perspective(300px) rotateX(65deg) translate(calc(var(--px, 0) * 20px), calc(var(--py, 0) * 14px));
+  transform-origin: bottom center;
+  -webkit-mask-image: linear-gradient(to top, black 0%, transparent 90%);
+  mask-image: linear-gradient(to top, black 0%, transparent 90%);
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: repeating-linear-gradient(to top, $grid-line 0 2px, transparent 2px 60px);
+    animation: grid-scroll 2s linear infinite;
+  }
+}
+
+.tron-stars {
+  position: absolute;
+  inset: 0;
+  opacity: 0.6;
+  transform: translate(calc(var(--px, 0) * 4px), calc(var(--py, 0) * 3px));
+  background-image:
+    radial-gradient(1px 1px at 10% 20%, #fff, transparent),
+    radial-gradient(1px 1px at 25% 55%, #fff, transparent),
+    radial-gradient(1px 1px at 40% 15%, #fff, transparent),
+    radial-gradient(1px 1px at 55% 65%, #fff, transparent),
+    radial-gradient(1px 1px at 70% 25%, #fff, transparent),
+    radial-gradient(1px 1px at 85% 50%, #fff, transparent),
+    radial-gradient(1px 1px at 92% 10%, #fff, transparent),
+    radial-gradient(1px 1px at 15% 80%, #fff, transparent),
+    radial-gradient(2px 2px at 80% 75%, $neon-cyan, transparent),
+    radial-gradient(2px 2px at 35% 35%, $neon-cyan, transparent);
+}
+
+@keyframes sun-pulse {
+  0%, 100% {
+    opacity: 0.85;
+    filter: brightness(1);
+  }
+  50% {
+    opacity: 1;
+    filter: brightness(1.15);
+  }
+}
+
+@keyframes grid-scroll {
+  from { background-position: 0 0; }
+  to { background-position: 0 60px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tron-sun,
+  .tron-grid::before {
+    animation: none !important;
+  }
+}
+
+.site-title,
+.site-description {
+  color: $neon-cyan;
+  text-shadow:
+    0 0 6px rgba(0, 255, 240, 0.8),
+    0 0 16px rgba(0, 255, 240, 0.5),
+    0 0 32px rgba(123, 47, 247, 0.4);
+}
+
+.header-icons .icon {
+  color: $neon-cyan;
+  border-color: $neon-cyan;
+  box-shadow: 0 0 8px rgba(0, 255, 240, 0.6);
+  &:hover, &:active {
+    color: $void;
+    background: $neon-cyan;
+    box-shadow: 0 0 16px rgba(0, 255, 240, 0.9), 0 0 32px rgba(255, 47, 208, 0.5);
+  }
+}
+
+.footer {
+  background: $void;
+  a:hover, a:active {
+    color: $neon-cyan;
+  }
+}

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -2,3 +2,9 @@ $main: #1a222c;
 $sec: #4B5664;
 $purple: #54516A;
 $cut: 550px;
+
+$neon-cyan: #00fff0;
+$neon-magenta: #ff2fd0;
+$neon-purple: #7b2ff7;
+$void: #0a0e1a;
+$grid-line: rgba(0, 255, 240, 0.35);

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -9,3 +9,4 @@
 @import 'about';
 @import 'projects';
 @import 'footer';
+@import 'tron';


### PR DESCRIPTION
## Summary
- Removes the Stack Overflow icon from the hero (no longer relevant)
- Reskins the hero into an 80s sci-fi/Tron-style neon theme: a glowing perspective grid floor, a pulsing horizon "sun", a subtle starfield, and neon cyan glow on the title/icons/footer links, with mouse/scroll-driven parallax (respects `prefers-reduced-motion`)

## Implementation notes
- The repo's gulp/node-sass build pipeline can't compile in this environment (node-gyp requires Python 2, only Python 3.11 available), so the new styles/script ship as standalone `assets/css/tron.css` + `assets/js/parallax.js` referenced directly from `_includes/head.html` / `_includes/footer.html`, rather than going through the gulp concat/minify step
- Equivalent source partials (`src/styles/_tron.scss`, `src/js/parallax.js`) are added and wired into `main.scss` so they're picked up automatically once the build pipeline is fixed

## Test plan
- [x] `jekyll build` succeeds and rendered `index.html` includes the new `.tron-bg`/`.tron-sun`/`.tron-grid`/`.tron-stars` markup, drops the Stack Overflow link, and references both new asset files
- [ ] Visual check in a real browser (couldn't run a headless browser in this sandbox — network policy blocked the Playwright Chromium download)
- [ ] Check at both mobile (<550px) and desktop widths
- [ ] Toggle `prefers-reduced-motion` and confirm animations/parallax stop


---
_Generated by [Claude Code](https://claude.ai/code/session_01CU7ofhG6CcPqekdXdi88s7)_