### PR TITLE
Restyle hero as synthwave title card + GitHub-driven project cards

### DIFF
--- a/.github/workflows/update-projects.yml
+++ b/.github/workflows/update-projects.yml
@@ -23,8 +23,16 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/user/repos?sort=updated&visibility=all&per_page=3" \
-          | jq '.[:3] | map({name, description, html_url, private})' \
-          > _data/projects.json
+          > /tmp/repos.json
+
+          if ! jq -e 'type == "array"' /tmp/repos.json > /dev/null 2>&1; then
+            echo "::error::GitHub API did not return a repo list — check that the GH_PROJECTS_PAT secret is set and valid."
+            echo "API response was:"
+            cat /tmp/repos.json
+            exit 1
+          fi
+
+          jq '.[:3] | map({name, description, html_url, private})' /tmp/repos.json > _data/projects.json
 
       - name: Show generated file
         run: cat _data/projects.json


### PR DESCRIPTION
## Summary
- Restyles the hero title with a Miami-Nights-style chrome/sunset gradient (`Audiowide`) plus a cursive (`Pacifico`) subtitle and glowing neon palm tree silhouettes, layered on the existing Tron sun/grid background.
- Adds 3 project cards under the socials, populated from `_data/projects.json`, in the same neon visual system (description shown when present, GitHub link shown only when the repo is public).
- Adds a monthly GitHub Actions workflow (`update-projects.yml`) that fetches your 3 most-recently-updated repos (public or private) and commits the refreshed data file; hardened to fail with a clear message instead of a cryptic `jq` error if the API call isn't authenticated.
- Cleanup: tightened the gulp `sass` glob to compile `main.scss` only (was compiling every partial into its own redundant CSS file), dropped the now-unused `tron.css` `<link>`, and removed unused placeholder images.

## Outstanding manual step
The workflow needs a classic PAT with `repo` scope added as the repo secret `GH_PROJECTS_PAT` (Settings → Secrets and variables → Actions) — it can't list private repos with the default `GITHUB_TOKEN`. The first manual run failed for exactly this reason; once the secret is added, re-run via the Actions tab.

## Test plan
- [x] Compiled SCSS locally (`sass`) and confirmed new gradient/palm-tree/card rules compile cleanly
- [x] Built the Jekyll site locally and screenshotted the hero + project cards
- [x] Verified the Liquid template guards (private repos hide the link, missing descriptions don't render an empty `<p>`)
- [x] Verified the workflow's new error-handling path against a simulated unauthenticated API response
- [ ] Add `GH_PROJECTS_PAT` secret and re-run the workflow to confirm real data populates `_data/projects.json`


---
_Generated by [Claude Code](https://claude.ai/code/session_013uWW7istGFmGiYcLaHApsM)_